### PR TITLE
Update serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,7 @@ provider:
         - s3:PutObject
       Resource:
         - "arn:aws:s3:::*"
+        - "arn:aws:s3:::*/"
 
 functions:
   optimize:


### PR DESCRIPTION
No momento que está adicionando * para qualquer bucket funciona, porém o ideal seria nomear o bucket e quando isso acontece é necessário setar dois paths de permissão, conforme exemplo:

          - "arn:aws:s3:::endpoint-images-pku"
          - "arn:aws:s3:::endpoint-images-pku/*"